### PR TITLE
feat: add ci feature flag for single-frame simulator exit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,8 @@ cargo build --release                        # hw (default)
 # Run the simulator locally (requires SDL2: sudo apt install libsdl2-dev)
 cargo run --no-default-features --features sim
 
-# Headless PNG snapshot (no SDL2 window, useful for CI)
-EG_SIMULATOR_DUMP=/tmp/pipulse.png cargo run --no-default-features --features sim
+# Headless PNG snapshot — single frame then exits (used in CI)
+EG_SIMULATOR_DUMP=/tmp/pipulse.png cargo run --no-default-features --features "sim,ci"
 
 # Lint
 cargo clippy
@@ -59,8 +59,9 @@ The `.deb` installs:
 |---|---|---|
 | `hw` | yes | Enables `src/display/hw.rs` — real SPI/GPIO hardware path |
 | `sim` | no | Enables `src/display/sim.rs` — SDL2 simulator window |
+| `ci` | no | When combined with `sim`, exits after the first frame (used for headless PNG snapshots in CI) |
 
-`hw` and `sim` are mutually exclusive at runtime (main.rs dispatches via `#[cfg]`). Always pass `--no-default-features` when enabling `sim`.
+`hw` and `sim` are mutually exclusive at runtime (main.rs dispatches via `#[cfg]`). Always pass `--no-default-features` when enabling `sim`. Combine `ci` with `sim` for CI screenshot dumps: `--no-default-features --features "sim,ci"`.
 
 ## Architecture
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ start = true
 default = ["hw"]
 hw  = []
 sim = ["dep:embedded-graphics-simulator"]
+ci  = []
 
 [dependencies]
 embedded-graphics    = "0.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,9 @@ fn run_sim() {
 
         setup.window.update(&setup.display);
 
+        #[cfg(feature = "ci")]
+        break;
+
         if setup.window.events().any(|e| e == SimulatorEvent::Quit) {
             break;
         }


### PR DESCRIPTION
Adds a `ci` feature flag that, when combined with `sim`, causes the simulator to exit after the first frame. This enables clean headless PNG snapshots in CI without affecting interactive development.

Closes #3

Generated with [Claude Code](https://claude.ai/code)