### PR TITLE
feat: multiple pages with button navigation and network sparklines

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,66 @@
+use embedded_hal::digital::InputPin;
+use linux_embedded_hal::{
+    CdevPin,
+    gpio_cdev::{Chip, LineRequestFlags},
+};
+
+use crate::AppError;
+
+const BTN_A: u32 = 23; // top button    → previous page (active-low)
+const BTN_B: u32 = 24; // bottom button → next page (active-low)
+
+pub enum ButtonEvent {
+    None,
+    Prev,
+    Next,
+}
+
+pub struct ButtonReader {
+    btn_a: CdevPin,
+    btn_b: CdevPin,
+    prev_a: bool,
+    prev_b: bool,
+}
+
+impl ButtonReader {
+    pub fn new() -> Result<Self, AppError> {
+        let mut chip = Chip::new("/dev/gpiochip0").map_err(|_| AppError::Gpio)?;
+        let btn_a = CdevPin::new(
+            chip.get_line(BTN_A)
+                .map_err(|_| AppError::Gpio)?
+                .request(LineRequestFlags::INPUT, 0, "pipulse-btn-a")
+                .map_err(|_| AppError::Gpio)?,
+        )
+        .map_err(|_| AppError::Gpio)?;
+        let btn_b = CdevPin::new(
+            chip.get_line(BTN_B)
+                .map_err(|_| AppError::Gpio)?
+                .request(LineRequestFlags::INPUT, 0, "pipulse-btn-b")
+                .map_err(|_| AppError::Gpio)?,
+        )
+        .map_err(|_| AppError::Gpio)?;
+        // Buttons are active-low; assume unpressed (high) at start.
+        Ok(Self {
+            btn_a,
+            btn_b,
+            prev_a: true,
+            prev_b: true,
+        })
+    }
+
+    /// Returns an edge-triggered event on the falling edge (button pressed).
+    pub fn poll(&mut self) -> ButtonEvent {
+        let a = self.btn_a.is_high().unwrap_or(true);
+        let b = self.btn_b.is_high().unwrap_or(true);
+        let event = if !a && self.prev_a {
+            ButtonEvent::Prev
+        } else if !b && self.prev_b {
+            ButtonEvent::Next
+        } else {
+            ButtonEvent::None
+        };
+        self.prev_a = a;
+        self.prev_b = b;
+        event
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -39,19 +39,22 @@ impl ButtonReader {
                 .map_err(|_| AppError::Gpio)?,
         )
         .map_err(|_| AppError::Gpio)?;
-        // Buttons are active-low; assume unpressed (high) at start.
+        // Buttons are active-low; initialize previous state from actual pin levels
+        // to avoid a spurious press event if a button is held at startup.
+        let prev_a = btn_a.is_high().map_err(|_| AppError::Gpio)?;
+        let prev_b = btn_b.is_high().map_err(|_| AppError::Gpio)?;
         Ok(Self {
             btn_a,
             btn_b,
-            prev_a: true,
-            prev_b: true,
+            prev_a,
+            prev_b,
         })
     }
 
     /// Returns an edge-triggered event on the falling edge (button pressed).
-    pub fn poll(&mut self) -> ButtonEvent {
-        let a = self.btn_a.is_high().unwrap_or(true);
-        let b = self.btn_b.is_high().unwrap_or(true);
+    pub fn poll(&mut self) -> Result<ButtonEvent, AppError> {
+        let a = self.btn_a.is_high().map_err(|_| AppError::Gpio)?;
+        let b = self.btn_b.is_high().map_err(|_| AppError::Gpio)?;
         let event = if !a && self.prev_a {
             ButtonEvent::Prev
         } else if !b && self.prev_b {
@@ -61,6 +64,6 @@ impl ButtonReader {
         };
         self.prev_a = a;
         self.prev_b = b;
-        event
+        Ok(event)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 mod display;
+#[cfg(all(feature = "hw", not(feature = "sim")))]
+mod input;
 mod metrics;
 mod ui;
 
+use std::collections::VecDeque;
 use embedded_graphics::{image::Image, pixelcolor::Rgb565, prelude::*};
 use embedded_icon::{
     NewIcon,
@@ -25,11 +28,17 @@ pub enum AppError {
 /// Height of one character row in pixels (matches mousefood's default font).
 const CHAR_H: i32 = 10;
 
+/// Number of network samples kept in history for the sparkline graphs.
+const HISTORY_LEN: usize = 40;
+
 /// Draw embedded-icon MDI icons at the pixel positions of rows 7-10.
 ///
 /// Must be called *after* `terminal.draw()` has completed and the display
 /// borrow has been released, so that the icons overwrite the leading spaces
 /// that Ratatui filled with background colour.
+///
+/// Only call this on the Overview page — the icon positions are baked into
+/// that layout.
 fn draw_icons<D>(display: &mut D, state: &ui::AppState)
 where
     D: DrawTarget<Color = Rgb565>,
@@ -101,8 +110,31 @@ fn main() -> Result<(), AppError> {
 fn run_hw() -> Result<(), AppError> {
     let mut display = display::hw::init()?;
     let mut cpu = metrics::CpuCollector::new();
+    let mut net = metrics::NetSampler::new();
+    let mut buttons = input::ButtonReader::new()?;
+    let mut page = ui::Page::default();
+    let mut rx_history: VecDeque<u64> = VecDeque::with_capacity(HISTORY_LEN);
+    let mut tx_history: VecDeque<u64> = VecDeque::with_capacity(HISTORY_LEN);
 
     loop {
+        // Handle button presses (edge-triggered, active-low)
+        match buttons.poll() {
+            input::ButtonEvent::Next => page = page.next(),
+            input::ButtonEvent::Prev => page = page.prev(),
+            input::ButtonEvent::None => {}
+        }
+
+        // Update network history ring buffers
+        let (rx, tx) = net.sample();
+        if rx_history.len() >= HISTORY_LEN {
+            rx_history.pop_front();
+        }
+        rx_history.push_back(rx);
+        if tx_history.len() >= HISTORY_LEN {
+            tx_history.pop_front();
+        }
+        tx_history.push_back(tx);
+
         let (ip, iface) = metrics::get_net_info();
         let state = ui::AppState {
             ip,
@@ -114,6 +146,9 @@ fn run_hw() -> Result<(), AppError> {
             temp: metrics::get_cpu_temp(),
             uptime: metrics::get_uptime_str(),
             load: metrics::get_loadavg(),
+            page,
+            rx_history: rx_history.clone(),
+            tx_history: tx_history.clone(),
         };
 
         {
@@ -124,7 +159,9 @@ fn run_hw() -> Result<(), AppError> {
             ui::render(&mut terminal, &state);
         }
 
-        draw_icons(&mut display, &state);
+        if state.page == ui::Page::Overview {
+            draw_icons(&mut display, &state);
+        }
 
         std::thread::sleep(Duration::from_secs(1));
     }
@@ -136,8 +173,23 @@ fn run_sim() {
 
     let mut setup = display::sim::init();
     let mut cpu = metrics::CpuCollector::new();
+    let mut net = metrics::NetSampler::new();
+    let mut page = ui::Page::default();
+    let mut rx_history: VecDeque<u64> = VecDeque::with_capacity(HISTORY_LEN);
+    let mut tx_history: VecDeque<u64> = VecDeque::with_capacity(HISTORY_LEN);
 
     loop {
+        // Update network history ring buffers
+        let (rx, tx) = net.sample();
+        if rx_history.len() >= HISTORY_LEN {
+            rx_history.pop_front();
+        }
+        rx_history.push_back(rx);
+        if tx_history.len() >= HISTORY_LEN {
+            tx_history.pop_front();
+        }
+        tx_history.push_back(tx);
+
         let (ip, iface) = metrics::get_net_info();
         let state = ui::AppState {
             ip,
@@ -149,6 +201,9 @@ fn run_sim() {
             temp: metrics::get_cpu_temp(),
             uptime: metrics::get_uptime_str(),
             load: metrics::get_loadavg(),
+            page,
+            rx_history: rx_history.clone(),
+            tx_history: tx_history.clone(),
         };
 
         {
@@ -158,14 +213,31 @@ fn run_sim() {
             ui::render(&mut terminal, &state);
         }
 
-        draw_icons(&mut setup.display, &state);
+        if state.page == ui::Page::Overview {
+            draw_icons(&mut setup.display, &state);
+        }
 
         setup.window.update(&setup.display);
 
         #[cfg(feature = "ci")]
         break;
 
-        if setup.window.events().any(|e| e == SimulatorEvent::Quit) {
+        let mut should_quit = false;
+        for event in setup.window.events() {
+            match event {
+                SimulatorEvent::Quit => should_quit = true,
+                SimulatorEvent::KeyDown { keycode, .. } => {
+                    use embedded_graphics_simulator::sdl2::keyboard::Keycode;
+                    match keycode {
+                        Keycode::Right | Keycode::D => page = page.next(),
+                        Keycode::Left | Keycode::A => page = page.prev(),
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+        }
+        if should_quit {
             break;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,8 @@ fn main() -> Result<(), AppError> {
 fn run_hw() -> Result<(), AppError> {
     let mut display = display::hw::init()?;
     let mut cpu = metrics::CpuCollector::new();
-    let mut net = metrics::NetSampler::new();
+    let (_, iface) = metrics::get_net_info();
+    let mut net = metrics::NetSampler::new(&iface);
     let mut buttons = input::ButtonReader::new()?;
     let mut page = ui::Page::default();
     let mut rx_history: VecDeque<u64> = VecDeque::with_capacity(HISTORY_LEN);
@@ -118,7 +119,7 @@ fn run_hw() -> Result<(), AppError> {
 
     loop {
         // Handle button presses (edge-triggered, active-low)
-        match buttons.poll() {
+        match buttons.poll()? {
             input::ButtonEvent::Next => page = page.next(),
             input::ButtonEvent::Prev => page = page.prev(),
             input::ButtonEvent::None => {}
@@ -173,7 +174,8 @@ fn run_sim() {
 
     let mut setup = display::sim::init();
     let mut cpu = metrics::CpuCollector::new();
-    let mut net = metrics::NetSampler::new();
+    let (_, iface) = metrics::get_net_info();
+    let mut net = metrics::NetSampler::new(&iface);
     let mut page = ui::Page::default();
     let mut rx_history: VecDeque<u64> = VecDeque::with_capacity(HISTORY_LEN);
     let mut tx_history: VecDeque<u64> = VecDeque::with_capacity(HISTORY_LEN);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,5 +1,47 @@
 use sysinfo::{Components, Disks, Networks, System};
 
+pub struct NetSampler {
+    prev_rx: u64,
+    prev_tx: u64,
+}
+
+impl NetSampler {
+    pub fn new() -> Self {
+        let (rx, tx) = Self::total_bytes();
+        Self {
+            prev_rx: rx,
+            prev_tx: tx,
+        }
+    }
+
+    fn total_bytes() -> (u64, u64) {
+        let networks = Networks::new_with_refreshed_list();
+        let mut rx = 0u64;
+        let mut tx = 0u64;
+        for (iface, data) in &networks {
+            if iface.starts_with("lo")
+                || iface.starts_with("docker")
+                || iface.starts_with("veth")
+            {
+                continue;
+            }
+            rx += data.total_received();
+            tx += data.total_transmitted();
+        }
+        (rx, tx)
+    }
+
+    /// Returns `(rx_bytes_per_sec, tx_bytes_per_sec)` since last call.
+    pub fn sample(&mut self) -> (u64, u64) {
+        let (rx, tx) = Self::total_bytes();
+        let rx_delta = rx.saturating_sub(self.prev_rx);
+        let tx_delta = tx.saturating_sub(self.prev_tx);
+        self.prev_rx = rx;
+        self.prev_tx = tx;
+        (rx_delta, tx_delta)
+    }
+}
+
 pub struct CpuCollector {
     sys: System,
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,44 +1,44 @@
+use std::time::Instant;
 use sysinfo::{Components, Disks, Networks, System};
 
 pub struct NetSampler {
+    iface: String,
     prev_rx: u64,
     prev_tx: u64,
+    last_sample: Instant,
 }
 
 impl NetSampler {
-    pub fn new() -> Self {
-        let (rx, tx) = Self::total_bytes();
+    pub fn new(iface: &str) -> Self {
+        let (rx, tx) = Self::iface_bytes(iface);
         Self {
+            iface: iface.to_string(),
             prev_rx: rx,
             prev_tx: tx,
+            last_sample: Instant::now(),
         }
     }
 
-    fn total_bytes() -> (u64, u64) {
+    fn iface_bytes(iface: &str) -> (u64, u64) {
         let networks = Networks::new_with_refreshed_list();
-        let mut rx = 0u64;
-        let mut tx = 0u64;
-        for (iface, data) in &networks {
-            if iface.starts_with("lo")
-                || iface.starts_with("docker")
-                || iface.starts_with("veth")
-            {
-                continue;
+        for (name, data) in &networks {
+            if name == iface {
+                return (data.total_received(), data.total_transmitted());
             }
-            rx += data.total_received();
-            tx += data.total_transmitted();
         }
-        (rx, tx)
+        (0, 0)
     }
 
     /// Returns `(rx_bytes_per_sec, tx_bytes_per_sec)` since last call.
     pub fn sample(&mut self) -> (u64, u64) {
-        let (rx, tx) = Self::total_bytes();
-        let rx_delta = rx.saturating_sub(self.prev_rx);
-        let tx_delta = tx.saturating_sub(self.prev_tx);
+        let elapsed = self.last_sample.elapsed().as_secs_f64().max(0.001);
+        let (rx, tx) = Self::iface_bytes(&self.iface);
+        let rx_bps = (rx.saturating_sub(self.prev_rx) as f64 / elapsed) as u64;
+        let tx_bps = (tx.saturating_sub(self.prev_tx) as f64 / elapsed) as u64;
         self.prev_rx = rx;
         self.prev_tx = tx;
-        (rx_delta, tx_delta)
+        self.last_sample = Instant::now();
+        (rx_bps, tx_bps)
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -100,8 +100,8 @@ fn render_page_header(frame: &mut Frame<'_>, area: Rect, title: &str, page: Page
     let width = area.width as usize;
     let indicator = format!("{}/{}", page.index(), Page::COUNT);
     // Layout: "─ " (2) + title + " ─...─ " (1 + dashes + 2) + indicator
-    // Fixed characters (excluding variable dashes): 2 + title.len() + 3 + indicator.len()
-    let fixed = 2 + title.len() + 3 + indicator.len();
+    // Use char count (not byte length) so multi-byte UTF-8 characters are measured correctly.
+    let fixed = 2 + title.chars().count() + 3 + indicator.chars().count();
     let extra_dashes = width.saturating_sub(fixed);
     frame.render_widget(
         Paragraph::new(Line::from(vec![

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,11 +1,45 @@
+use std::collections::VecDeque;
 use ratatui::{
     Frame, Terminal,
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Style},
     text::{Line, Span},
-    widgets::{Gauge, Paragraph},
+    widgets::{Gauge, Paragraph, Sparkline},
 };
+
+#[derive(Clone, Copy, PartialEq, Default)]
+pub enum Page {
+    #[default]
+    Overview,
+    Network,
+}
+
+impl Page {
+    pub const COUNT: usize = 2;
+
+    pub fn next(self) -> Self {
+        match self {
+            Page::Overview => Page::Network,
+            Page::Network => Page::Overview,
+        }
+    }
+
+    pub fn prev(self) -> Self {
+        // Two pages: prev wraps the same way as next.
+        match self {
+            Page::Overview => Page::Network,
+            Page::Network => Page::Overview,
+        }
+    }
+
+    fn index(self) -> usize {
+        match self {
+            Page::Overview => 1,
+            Page::Network => 2,
+        }
+    }
+}
 
 pub struct AppState {
     pub ip: String,
@@ -17,6 +51,9 @@ pub struct AppState {
     pub temp: Option<f32>,
     pub uptime: String,
     pub load: String,
+    pub page: Page,
+    pub rx_history: VecDeque<u64>,
+    pub tx_history: VecDeque<u64>,
 }
 
 fn traffic_color(pct: u8, warn: u8, crit: u8) -> Color {
@@ -58,79 +95,158 @@ fn render_gauge_row(frame: &mut Frame<'_>, area: Rect, label: &str, pct: u8, war
     );
 }
 
+/// Renders a header line: "─ <title> ─...─ N/M"
+fn render_page_header(frame: &mut Frame<'_>, area: Rect, title: &str, page: Page) {
+    let width = area.width as usize;
+    let indicator = format!("{}/{}", page.index(), Page::COUNT);
+    // Layout: "─ " (2) + title + " ─...─ " (1 + dashes + 2) + indicator
+    // Fixed characters (excluding variable dashes): 2 + title.len() + 3 + indicator.len()
+    let fixed = 2 + title.len() + 3 + indicator.len();
+    let extra_dashes = width.saturating_sub(fixed);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("─ ", Style::default().fg(Color::DarkGray)),
+            Span::styled(title.to_string(), Style::default().fg(Color::Cyan)),
+            Span::styled(
+                format!(" {}─ ", "─".repeat(extra_dashes)),
+                Style::default().fg(Color::DarkGray),
+            ),
+            Span::styled(indicator, Style::default().fg(Color::White)),
+        ])),
+        area,
+    );
+}
+
+fn fmt_rate(bps: u64) -> String {
+    if bps >= 1_000_000 {
+        format!("{:.1} MB/s", bps as f64 / 1_000_000.0)
+    } else if bps >= 1_000 {
+        format!("{:.0} KB/s", bps as f64 / 1_000.0)
+    } else {
+        format!("{} B/s", bps)
+    }
+}
+
+fn render_overview(frame: &mut Frame<'_>, state: &AppState) {
+    let divider: String = "─".repeat(frame.area().width as usize);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // [0] header
+            Constraint::Length(1), // [1] CPU
+            Constraint::Length(1), // [2] spacer
+            Constraint::Length(1), // [3] Mem
+            Constraint::Length(1), // [4] spacer
+            Constraint::Length(1), // [5] Disk
+            Constraint::Length(1), // [6] divider
+            Constraint::Length(2), // [7] IP
+            Constraint::Length(2), // [8] Temp
+            Constraint::Length(2), // [9] Uptime
+            Constraint::Length(2), // [10] Load
+            Constraint::Min(0),
+        ])
+        .split(frame.area());
+
+    render_page_header(frame, rows[0], &state.hostname, state.page);
+
+    render_gauge_row(frame, rows[1], "CPU", state.cpu_pct, 50, 80);
+    render_gauge_row(frame, rows[3], "Mem", state.mem_pct, 60, 85);
+    render_gauge_row(frame, rows[5], "Dsk", state.disk_pct, 70, 90);
+
+    frame.render_widget(
+        Paragraph::new(divider.as_str()).style(Style::default().fg(Color::DarkGray)),
+        rows[6],
+    );
+
+    // Leading spaces leave room for the embedded-icon drawn in main.rs
+    frame.render_widget(
+        Paragraph::new(format!("    {}", state.ip))
+            .style(Style::default().fg(Color::White)),
+        rows[7],
+    );
+
+    let temp_str = state
+        .temp
+        .map_or("    --".into(), |t| format!("    {t:.1}\u{00b0}C"));
+    let temp_col = state.temp.map_or(Color::Gray, temp_color);
+    frame.render_widget(
+        Paragraph::new(temp_str).style(Style::default().fg(temp_col)),
+        rows[8],
+    );
+
+    frame.render_widget(
+        Paragraph::new(format!("    {}", state.uptime))
+            .style(Style::default().fg(Color::Gray)),
+        rows[9],
+    );
+
+    frame.render_widget(
+        Paragraph::new(format!("    {}", state.load))
+            .style(Style::default().fg(Color::Gray)),
+        rows[10],
+    );
+}
+
+fn render_network(frame: &mut Frame<'_>, state: &AppState) {
+    let divider: String = "─".repeat(frame.area().width as usize);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // [0] header (iface + IP + page indicator)
+            Constraint::Length(1), // [1] divider
+            Constraint::Length(1), // [2] Rx label + rate
+            Constraint::Length(3), // [3] Rx sparkline
+            Constraint::Length(1), // [4] Tx label + rate
+            Constraint::Length(3), // [5] Tx sparkline
+            Constraint::Min(0),
+        ])
+        .split(frame.area());
+
+    let iface_ip = format!("{} {}", state.iface, state.ip);
+    render_page_header(frame, rows[0], &iface_ip, state.page);
+
+    frame.render_widget(
+        Paragraph::new(divider.as_str()).style(Style::default().fg(Color::DarkGray)),
+        rows[1],
+    );
+
+    let rx_data: Vec<u64> = state.rx_history.iter().copied().collect();
+    let tx_data: Vec<u64> = state.tx_history.iter().copied().collect();
+    let current_rx = rx_data.last().copied().unwrap_or(0);
+    let current_tx = tx_data.last().copied().unwrap_or(0);
+
+    frame.render_widget(
+        Paragraph::new(format!("Rx  {}", fmt_rate(current_rx)))
+            .style(Style::default().fg(Color::Green)),
+        rows[2],
+    );
+    frame.render_widget(
+        Sparkline::default()
+            .data(&rx_data)
+            .style(Style::default().fg(Color::Green)),
+        rows[3],
+    );
+
+    frame.render_widget(
+        Paragraph::new(format!("Tx  {}", fmt_rate(current_tx)))
+            .style(Style::default().fg(Color::Cyan)),
+        rows[4],
+    );
+    frame.render_widget(
+        Sparkline::default()
+            .data(&tx_data)
+            .style(Style::default().fg(Color::Cyan)),
+        rows[5],
+    );
+}
+
 pub fn render<B: Backend>(terminal: &mut Terminal<B>, state: &AppState) {
     terminal
-        .draw(|frame| {
-            let width = frame.area().width as usize;
-            let divider: String = "─".repeat(width);
-
-            let rows = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([
-                    Constraint::Length(1), // [0] header divider
-                    Constraint::Length(1), // [1] CPU
-                    Constraint::Length(1), // [2] spacer
-                    Constraint::Length(1), // [3] Mem
-                    Constraint::Length(1), // [4] spacer
-                    Constraint::Length(1), // [5] Disk
-                    Constraint::Length(1), // [6] divider
-                    Constraint::Length(2), // [7] IP
-                    Constraint::Length(2), // [8] Temp
-                    Constraint::Length(2), // [9] Uptime
-                    Constraint::Length(2), // [10] Load
-                    Constraint::Min(0),
-                ])
-                .split(frame.area());
-
-            let tail_len = width.saturating_sub(state.hostname.len() + 3);
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("─ ", Style::default().fg(Color::DarkGray)),
-                    Span::styled(state.hostname.as_str(), Style::default().fg(Color::Cyan)),
-                    Span::styled(
-                        format!(" {}", "─".repeat(tail_len)),
-                        Style::default().fg(Color::DarkGray),
-                    ),
-                ])),
-                rows[0],
-            );
-
-            render_gauge_row(frame, rows[1], "CPU", state.cpu_pct, 50, 80);
-            render_gauge_row(frame, rows[3], "Mem", state.mem_pct, 60, 85);
-            render_gauge_row(frame, rows[5], "Dsk", state.disk_pct, 70, 90);
-
-            frame.render_widget(
-                Paragraph::new(divider.as_str()).style(Style::default().fg(Color::DarkGray)),
-                rows[6],
-            );
-
-            // Leading spaces leave room for the embedded-icon drawn in main.rs
-            frame.render_widget(
-                Paragraph::new(format!("    {}", state.ip))
-                    .style(Style::default().fg(Color::White)),
-                rows[7],
-            );
-
-            let temp_str = state
-                .temp
-                .map_or("    --".into(), |t| format!("    {t:.1}\u{00b0}C"));
-            let temp_col = state.temp.map_or(Color::Gray, temp_color);
-            frame.render_widget(
-                Paragraph::new(temp_str).style(Style::default().fg(temp_col)),
-                rows[8],
-            );
-
-            frame.render_widget(
-                Paragraph::new(format!("    {}", state.uptime))
-                    .style(Style::default().fg(Color::Gray)),
-                rows[9],
-            );
-
-            frame.render_widget(
-                Paragraph::new(format!("    {}", state.load))
-                    .style(Style::default().fg(Color::Gray)),
-                rows[10],
-            );
+        .draw(|frame| match state.page {
+            Page::Overview => render_overview(frame, state),
+            Page::Network => render_network(frame, state),
         })
         .unwrap();
 }


### PR DESCRIPTION
Adds two-page navigation cycled via the miniPiTFT GPIO 23/24 buttons.

- New `src/input.rs` with `ButtonReader`: polls GPIO 23 (top=prev) and GPIO 24 (bottom=next), active-low with falling-edge detection
- New `metrics::NetSampler`: samples Rx/Tx byte deltas each tick from `sysinfo::Networks`
- `ui::Page` enum (Overview/Network) with `next()`/`prev()` wrap-around; page indicator ("1/2", "2/2") in every header
- Network page shows live Rx (green) and Tx (cyan) Sparkline graphs with formatted rate labels (B/s / KB/s / MB/s); 40-sample history ring buffer
- Simulator maps Left/A -> prev page and Right/D -> next page for local testing without hardware

Closes #13

Generated with [Claude Code](https://claude.ai/code)